### PR TITLE
Fix recipe display issues and add emojis

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,9 +10,10 @@
 <body>
     <div class="landing-page">
         <h1 class="landing-title">Cook a Feast</h1>
-        <p class="recipe-list-prompt">Click below to load</p>
+        <p class="recipe-list-prompt">Click below to load:</p>
         <ul class="recipe-list">
             <li><a href="recipes/tonys-secret-vegan-curry.html">Tony's Original Secret Vegan Curry Recipe</a></li>
+            <li class="separator">~</li>
             <li><a href="recipes/harrys-broccoli-tagliatelle.html">Harry's Broccoli Tagliatelle</a></li>
         </ul>
     </div>

--- a/recipes/harrys-broccoli-tagliatelle.html
+++ b/recipes/harrys-broccoli-tagliatelle.html
@@ -32,18 +32,18 @@
                 <div class="ingredients-section">
                     <h2 class="section-title">Ingredienti</h2>
                     <ul class="ingredients-list">
-                        <li><input type="checkbox" id="broc-ing1"><label for="broc-ing1">1 whole broccoli, cut into florets</label></li>
-                        <li><input type="checkbox" id="broc-ing2"><label for="broc-ing2">Tagliatelle (cooks in 10 minutes)</label></li>
-                        <li><input type="checkbox" id="broc-ing3"><label for="broc-ing3">Generous knob of butter, plus extra if you like it richer</label></li>
-                        <li><input type="checkbox" id="broc-ing4"><label for="broc-ing4">All-purpose seasoning</label></li>
-                        <li><input type="checkbox" id="broc-ing5"><label for="broc-ing5">Dried oregano</label></li>
-                        <li><input type="checkbox" id="broc-ing6"><label for="broc-ing6">Dried basil</label></li>
-                        <li><input type="checkbox" id="broc-ing7"><label for="broc-ing7">Chilli flakes (optional)</label></li>
-                        <li><input type="checkbox" id="broc-ing8"><label for="broc-ing8">Mozzarella, pull apart and add to dish</label></li>
-                        <li><input type="checkbox" id="broc-ing9"><label for="broc-ing9">Grana Padano, grated</label></li>
-                        <li><input type="checkbox" id="broc-ing10"><label for="broc-ing10">Parmesan, grated</label></li>
-                        <li><input type="checkbox" id="broc-ing11"><label for="broc-ing11">Salt (for the pasta water and seasoning)</label></li>
-                        <li><input type="checkbox" id="broc-ing12"><label for="broc-ing12">Freshly ground black pepper</label></li>
+                        <li><input type="checkbox" id="broc-ing1"><label for="broc-ing1">🥦 1 whole broccoli, cut into florets</label></li>
+                        <li><input type="checkbox" id="broc-ing2"><label for="broc-ing2">🍝 Tagliatelle (cooks in 10 minutes)</label></li>
+                        <li><input type="checkbox" id="broc-ing3"><label for="broc-ing3">🧈 Generous knob of butter, plus extra if you like it richer</label></li>
+                        <li><input type="checkbox" id="broc-ing4"><label for="broc-ing4">🧂 All-purpose seasoning</label></li>
+                        <li><input type="checkbox" id="broc-ing5"><label for="broc-ing5">🌿 Dried oregano</label></li>
+                        <li><input type="checkbox" id="broc-ing6"><label for="broc-ing6">🌿 Dried basil</label></li>
+                        <li><input type="checkbox" id="broc-ing7"><label for="broc-ing7">🌶️ Chilli flakes (optional)</label></li>
+                        <li><input type="checkbox" id="broc-ing8"><label for="broc-ing8">🧀 Mozzarella, pull apart and add to dish</label></li>
+                        <li><input type="checkbox" id="broc-ing9"><label for="broc-ing9">🧀 Grana Padano, grated</label></li>
+                        <li><input type="checkbox" id="broc-ing10"><label for="broc-ing10">🧀 Parmesan, grated</label></li>
+                        <li><input type="checkbox" id="broc-ing11"><label for="broc-ing11">🧂 Salt (for the pasta water and seasoning)</label></li>
+                        <li><input type="checkbox" id="broc-ing12"><label for="broc-ing12">⚫ Freshly ground black pepper</label></li>
                     </ul>
                 </div>
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -161,8 +161,6 @@ body {
     color: #5d4e37;
     line-height: 1.6;
     text-align: justify;
-    display: flex;
-    flex-direction: column;
 }
 
 .instructions-list li::before {


### PR DESCRIPTION
- Add a colon after 'load' on the main page.
- Add a tilde separator between recipes on the main page.
- Add emojis to the broccoli pasta recipe's ingredients.
- Fix a CSS issue causing unwanted line breaks in recipe instructions.