### PR TITLE
The cooking instructions were displaying step numbers twice. This was…

### DIFF
--- a/recipes/harrys-broccoli-tagliatelle.html
+++ b/recipes/harrys-broccoli-tagliatelle.html
@@ -51,43 +51,33 @@
                     <h2 class="section-title">Preparazione</h2>
                     <ol class="instructions-list">
                         <li>
-                            Step 1
                             <p>Bring a large pot of salted water to the boil.</p>
                         </li>
                         <li>
-                            Step 2
                             <p>Add the tagliatelle and cook for 10 minutes. Add the broccoli florets to the pot for the final 5 minutes so both finish together.</p>
                         </li>
                         <li>
-                            Step 3
                             <p>Drain the pasta and broccoli together, reserving a splash of the pasta water.</p>
                         </li>
                         <li>
-                            Step 4
                             <p>Return the empty pot to low heat and add a generous knob of butter; let it melt until slightly foamy.</p>
                         </li>
                         <li>
-                            Step 5
                             <p>Stir in the all-purpose seasoning, oregano, basil and chilli flakes if using; warm briefly to release the flavours.</p>
                         </li>
                         <li>
-                            Step 6
                             <p>Put the drained tagliatelle and broccoli back into the pot and toss in the butter and herbs. Add a little reserved pasta water if it seems dry.</p>
                         </li>
                         <li>
-                            Step 7
                             <p>Pull apart the mozzarella and add it to the pasta, then add Grana Padano and Parmesan, grated. Toss until the cheeses start to melt and coat the pasta; add more butter if you want it even richer.</p>
                         </li>
                         <li>
-                            Step 8
                             <p>Season to taste with salt and freshly ground black pepper.</p>
                         </li>
                         <li>
-                            Step 9
                             <p>Serve immediately, with extra grated cheese or chilli flakes if desired.</p>
                         </li>
                         <li>
-                            Step 10
                             <p>Optional: Add a splash of hot sauce at the end for an extra kick.</p>
                         </li>
                     </ol>

--- a/recipes/tonys-secret-vegan-curry.html
+++ b/recipes/tonys-secret-vegan-curry.html
@@ -72,43 +72,33 @@
                     <h2 class="section-title">Preparazione</h2>
                     <ol class="instructions-list">
                         <li>
-                            Step 1
                             <p><span class="instruction-amount" data-base="200" data-unit="g">Soak 200g</span> of red lentils in <span class="instruction-amount" data-base="200" data-unit="ml">200ml</span> of water overnight.</p>
                         </li>
                         <li>
-                            Step 2
                             <p>Dice the red bell peppers into 2cm squares and chop the cauliflower into florets smaller than 3cm. Toss the diced peppers in a little oil and roast them in an oven preheated to 200°C for 15-20 minutes until roasted.</p>
                         </li>
                         <li>
-                            Step 3
                             <p>Finely chop the onions and chop the <span class="instruction-amount" data-base="4">4 cloves</span> of garlic. Grate a 1-inch piece of ginger.</p>
                         </li>
                         <li>
-                            Step 4
                             <p>Heat <span class="instruction-amount" data-base="95" data-unit="ml">95ml</span> of oil in a pan and fry the garlic until brown, for approximately 1 minute. Add the onions, <span class="instruction-amount" data-base="0.75" data-unit="tsp">3/4 tsp</span> of salt, <span class="instruction-amount" data-base="4">4</span> cinnamon sticks, and the bay leaf, and cook until the onions are soft.</p>
                         </li>
                         <li>
-                            Step 5
                             <p>Once the onions are soft, add the grated ginger, <span class="instruction-amount" data-base="2" data-unit="tsp">2 tsp</span> of Madras powder, 1 tsp turmeric, <span class="instruction-amount" data-base="1" data-unit="tsp">1 tsp</span> ground cumin, <span class="instruction-amount" data-base="1" data-unit="tsp">1 tsp</span> ground coriander, <span class="instruction-amount" data-base="0.5" data-unit="tsp">1/2 tsp</span> garam masala, and a pinch of chili powder. Cook for about 30 minutes on a medium to low heat.</p>
                         </li>
                         <li>
-                            Step 6
                             <p>Add a tin of chopped tomatoes and cook on medium/low heat for 30 minutes until the oil rises to the top, stirring regularly to prevent sticking.</p>
                         </li>
                         <li>
-                            Step 7
                             <p>Add <span class="instruction-amount" data-base="650" data-unit="ml">650ml</span> of water, <span class="instruction-amount" data-base="200" data-unit="g">200g</span> of tomato puree, and <span class="instruction-amount" data-base="2" data-unit="tsp">2 tsp</span> of sugar to the curry base.</p>
                         </li>
                         <li>
-                            Step 8
                             <p>Add the soaked lentils and the cauliflower florets. Simmer for 15 minutes until the lentils have a slight bite.</p>
                         </li>
                         <li>
-                            Step 9
                             <p>Finally, add the chickpeas, the roasted peppers, and the baby spinach. Bring back to a simmer.</p>
                         </li>
                         <li>
-                            Step 10
                             <p>Garnish with fresh coriander if desired and serve hot.</p>
                         </li>
                     </ol>


### PR DESCRIPTION
… because the step number was hardcoded in the HTML files and also generated by a CSS counter.

This change removes the hardcoded "Step X" text from the recipe HTML files. The step numbers are now solely handled by the CSS `::before` pseudo-element and the `counter-increment` property, which was already in place.

This resolves the visual bug and makes the code cleaner by removing redundant content.